### PR TITLE
add email activation for a new user

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,7 +4,6 @@ class SessionsController < ApplicationController
   end
 
   def create
-    # require "pry"; binding.pry
     if (user = User.find_by(email: params[:session][:email])) && user&.authenticate(params[:session][:password])
       session[:user_id] = user.id
       redirect_to dashboard_path

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,11 +16,20 @@ class UsersController < ApplicationController
     user = User.create(user_params)
     if user.save
       session[:user_id] = user.id
+      UserActivationMailer.inform(user).deliver_now
       redirect_to dashboard_path
+      flash[:success] = "Logged in as #{user_params[:email]}. This account has not yet been activated. Please check your email."
     else
       flash[:error] = 'Username already exists'
       render :new
     end
+  end
+
+  def update
+    user = User.find(params[:user_id])
+    user.update(activated?: true)
+    redirect_to dashboard_path
+    flash[:success] = 'Thanks for activating buddy :)'
   end
 
   private

--- a/app/facades/follower_facade.rb
+++ b/app/facades/follower_facade.rb
@@ -4,6 +4,7 @@ class FollowerFacade
               :id
 
   def initialize(info)
+    require 'pry'; binding.pry
     @name = info['login']
     @url_link = info['html_url']
     @id = info['id']

--- a/app/mailers/user_activation_mailer.rb
+++ b/app/mailers/user_activation_mailer.rb
@@ -1,0 +1,6 @@
+class UserActivationMailer < ApplicationMailer
+  def inform(user)
+    @new_user = user
+    mail(to: user.email, subject: 'Activate your account')
+  end
+end

--- a/app/views/user_activation_mailer/inform.html.erb
+++ b/app/views/user_activation_mailer/inform.html.erb
@@ -1,0 +1,3 @@
+Click this button to activate your account!
+
+<%= link_to "Activate account", "/activate/users/#{@new_user.id}" %>

--- a/app/views/user_activation_mailer/inform.text.erb
+++ b/app/views/user_activation_mailer/inform.text.erb
@@ -1,0 +1,3 @@
+Click this button to activate your account!
+
+<%= link_to "Activate account", "users/#{@new_user.id}" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,11 +6,13 @@
   <ul>
     <li> <%= current_user.first_name  %> <%= current_user.last_name %> </li>
     <li> <%= current_user.email%> </li>
+    <% if current_user.activated? %>
+      <li>Account status: Active</li>
+    <% end %>
   </ul>
   <section>
     <% if session[:github] == nil %>
       <%= link_to "Log in to GitHub", '/auth/github', class: "btn bg-teal btn-outline " %>
-      <%# <%= button_to "Log in to GitHub", '/auth/github', class: "btn bg-teal btn-outline " %>
     <% else %>
     <section class="github">
     <h3>Github Repositories</h3>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,6 +14,9 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
 
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = { :address => "localhost", :port => 1025 }
+
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
   if Rails.root.join('tmp', 'caching-dev.txt').exist?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,11 +39,13 @@ Rails.application.routes.draw do
   # Is this being used?
   get '/video', to: 'video#show'
 
-  resources :users, only: [:new, :create, :update, :edit]
+  resources :users, only: [:new, :create, :edit]
 
   resources :tutorials, only: [:show, :index, :update] do
     resources :videos, only: [:show, :index]
   end
 
   resources :user_videos, only:[:create, :destroy]
+
+  get '/activate/users/:user_id', to: 'users#update'
 end

--- a/db/migrate/20200212183521_add_activated_to_users.rb
+++ b/db/migrate/20200212183521_add_activated_to_users.rb
@@ -1,0 +1,5 @@
+class AddActivatedToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :activated?, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_10_213005) do
+ActiveRecord::Schema.define(version: 2020_02_12_183521) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,6 +75,7 @@ ActiveRecord::Schema.define(version: 2020_02_10_213005) do
     t.string "token"
     t.string "uid"
     t.string "login"
+    t.boolean "activated?", default: false
     t.index ["email"], name: "index_users_on_email"
   end
 

--- a/spec/features/email/user_can_email_invitations_spec.rb
+++ b/spec/features/email/user_can_email_invitations_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe 'Users can send invitations' do
+  it "from their dashboard" do
+    user = create(:user)
+    # follower = FollowerFacade.new({ 'login' => 'User', 'html_url' => 'google.com', 'id' => 53549145})
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit dashboard_path
+
+    # within '#invite-'
+  end
+end

--- a/spec/features/email/user_must_activate_account_spec.rb
+++ b/spec/features/email/user_must_activate_account_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe 'As a new user' do
+  describe 'when I register my account' do
+    it 'tells me to activate my account from my email' do
+      visit register_path
+
+      email = 'billy@gmail.com'
+
+      fill_in :user_email, with: email
+      fill_in :user_first_name, with: 'Billy'
+      fill_in :user_last_name, with: 'Bob'
+      fill_in :user_password, with: 'secret'
+      fill_in :user_password_confirmation, with: 'secret'
+
+      click_on 'Create Account'
+
+      expect(current_path).to eq(dashboard_path)
+      expect(page).to have_content("Logged in as #{email}")
+      expect(page).to have_content("This account has not yet been activated. Please check your email.")
+      expect(page).to_not have_content('Account status: Active')
+    end
+
+    it 'sends me an email with a link to activate my account' do
+      visit register_path
+
+      email = 'billy@gmail.com'
+
+      fill_in :user_email, with: email
+      fill_in :user_first_name, with: 'Billy'
+      fill_in :user_last_name, with: 'Bob'
+      fill_in :user_password, with: 'secret'
+      fill_in :user_password_confirmation, with: 'secret'
+
+      expect do
+        click_on 'Create Account' 
+      end.to change { ActionMailer::Base.deliveries.count }.by(1)
+      
+      user = User.last
+      visit "/activate/users/#{user.id}"
+
+      expect(current_path).to eq(dashboard_path)
+
+      flash = 'Thanks for activating buddy :)'
+
+      expect(page).to have_content(flash)
+      expect(page).to have_content('Account status: Active')
+    end
+  end
+end


### PR DESCRIPTION
**Functionality:**
- Users can activate their account after an email is sent to them after newly registering
- Users see activation status on their dashboard
- Added activated? column to users table

**Testing:**
- all tests passing except .video

**Related Issues:**
#18 